### PR TITLE
Added auto_add=True to enable new directories to be watched

### DIFF
--- a/spotter/spotter.py
+++ b/spotter/spotter.py
@@ -35,7 +35,7 @@ class Spotter(pyinotify.ProcessEvent):
     def inotify_loop(self):
         watch_manager = pyinotify.WatchManager()
         notifier = pyinotify.Notifier(watch_manager, self)
-        watch_manager.add_watch('.', Spotter.INOTIFY_EVENT_MASK, rec=True)
+        watch_manager.add_watch('.', Spotter.INOTIFY_EVENT_MASK, rec=True, auto_add=True)
         notifier.loop()
 
     def process_default(self, event):


### PR DESCRIPTION
Per the pyinotify FAQ:
I've watched a directory with argument rec=True but after that if a new directory is created inside, it is not automatically watched
You'll most likely want to use an additional argument auto_add=True when calling the method add_watch()
https://github.com/seb-m/pyinotify/wiki/Frequently-Asked-Questions
